### PR TITLE
Avoid warning because of unused local typedef

### DIFF
--- a/include/asiochan/select_result.hpp
+++ b/include/asiochan/select_result.hpp
@@ -118,8 +118,6 @@ namespace asiochan
         [[nodiscard]] auto matches(T const& channel) const noexcept -> bool
         // clang-format on
         {
-            using SendType = typename T::send_type;
-
             return std::visit(
                 [&](auto const& result)
                 { return result.matches(channel); },


### PR DESCRIPTION
delete the line 121 which causes the following  warning in gcc-12:
"warning: typedef ‘using SendType = typename T::send_type’ locally defined but not used"